### PR TITLE
change add buttons from click events to form submit

### DIFF
--- a/src/sections/group/matches/matches.component.html
+++ b/src/sections/group/matches/matches.component.html
@@ -6,7 +6,7 @@
 
 <div class="matches-container">
     <div class="new-match" *ngIf="!matchesLoading">
-        <form class="match-form">
+        <form class="match-form" (ngSubmit)="createMatch(playerOne.value, playerTwo.value, winner.value)">
             <mat-form-field>
                 <input #playerOne matInput placeholder="Player 1">
             </mat-form-field>
@@ -16,10 +16,11 @@
             <mat-form-field>
                 <input #winner matInput placeholder="Winner">
             </mat-form-field>
+
+            <button mat-mini-fab>
+                <mat-icon aria-label="Record Match">done</mat-icon>
+            </button>
         </form>
-        <button mat-mini-fab (click)="createMatch(playerOne.value, playerTwo.value, winner.value)">
-            <mat-icon aria-label="Record Match">done</mat-icon>
-        </button>
     </div>
 
     <mat-table #matchesTable class="matches-table" [dataSource]="matchesDataSource"

--- a/src/sections/group/matches/matches.component.scss
+++ b/src/sections/group/matches/matches.component.scss
@@ -17,8 +17,4 @@
 
 .new-match {
     margin-bottom: 50px;
-
-    > * {
-        display: inline-block;
-    }
 }

--- a/src/sections/group/players/players.component.html
+++ b/src/sections/group/players/players.component.html
@@ -1,14 +1,13 @@
 <div class="players-container">
-    <div class="new-player">
-        <form class="player-form">
-            <mat-form-field>
-                <input #newPlayer matInput placeholder="Add a Player">
-            </mat-form-field>
-        </form>
-        <button mat-mini-fab (click)="createPlayer(newPlayer.value)">
+    <form class="new-player" (ngSubmit)="createPlayer(newPlayer.value)">
+        <mat-form-field>
+            <input #newPlayer matInput placeholder="Add a Player">
+        </mat-form-field>
+
+        <button mat-mini-fab>
             <mat-icon aria-label="Add a Player">person_add</mat-icon>
         </button>
-    </div>
+    </form>
 
     <mat-table #playersTable class="players-table" [dataSource]="playersDataSource"
         matSort

--- a/src/sections/group/players/players.component.scss
+++ b/src/sections/group/players/players.component.scss
@@ -25,8 +25,4 @@
     width: 500px;
     display: flex;
     justify-content: center;
-
-    > * {
-        display: inline-block;
-    }     
 }

--- a/src/sections/home/home.component.html
+++ b/src/sections/home/home.component.html
@@ -1,12 +1,13 @@
-<div class="new-group" *ngIf="!(group$ | async).loading">
-    <form class="group-form">
+<div *ngIf="!(group$ | async).loading">
+    <form class="group-form" (ngSubmit)="createGroup(newGroup.value)">
         <mat-form-field class="example-full-width">
             <input #newGroup matInput placeholder="Create a New Group">
         </mat-form-field>
+
+        <button mat-fab>
+            <mat-icon aria-label="Add a Group">group_add</mat-icon>
+        </button>
     </form>
-    <button mat-fab (click)="createGroup(newGroup.value)">
-        <mat-icon aria-label="Add a Group">group_add</mat-icon>
-    </button>
 </div>
 <mat-progress-spinner
     class="loading-group"

--- a/src/sections/home/home.component.scss
+++ b/src/sections/home/home.component.scss
@@ -2,19 +2,14 @@
   min-width: 150px;
   max-width: 500px;
   width: 100%;
+  margin: 0 auto;
 
   > mat-form-field {
     width: 100%;
   }
-}
 
-.new-group {
   display: flex;
   justify-content: center;
-
-  > * {
-    display: inline-block;
-  }
 }
 
 .loading-group {

--- a/src/sections/sections.module.ts
+++ b/src/sections/sections.module.ts
@@ -1,4 +1,5 @@
 import { NgModule } from "@angular/core";
+import { FormsModule } from "@angular/forms";
 import { HomeComponent } from "./home/home.component";
 import { ComponentsModule } from "../components/components.module";
 import { PageNotFoundComponent } from "./notfound/notfound.component";
@@ -24,6 +25,7 @@ import { PlayersComponent } from "./group/players/players.component";
   ],
   imports: [
     ComponentsModule,
+    FormsModule,
     MatIconModule,
     MatInputModule,
     MatButtonModule,


### PR DESCRIPTION
This is what Pearl and I were ranting about...

By default hitting enter on an input in a form submits it. By default a form submission basically reload s the page, that's why using the enter key wasn't working.

If a `<button>` is in a form then by default clicking it submits the form, so now pressing the button or enter key submits the form.

`(ngSubmit)` handles the submit event via JS instead of by submitting the full page and reload the app. This requires the `FormsModule`.

Moving the buttons into the form also simplified the css a bit, and could probably be simplified more (like removing some wrapper `<div>`s).

Note that I've failed to get any calls to the server working, so don't trust me on this...